### PR TITLE
Add the possibilty to set the minmal levels of assurance in the view.

### DIFF
--- a/digid_eherkenning/admin.py
+++ b/digid_eherkenning/admin.py
@@ -34,6 +34,7 @@ class DigidConfigurationAdmin(PrivateMediaMixin, SingletonModelAdmin):
                 "fields": (
                     "entity_id",
                     "base_url",
+                    "artifact_resolve_content_type",
                     "want_assertions_signed",
                     "want_assertions_encrypted",
                     "signature_algorithm",

--- a/digid_eherkenning/choices.py
+++ b/digid_eherkenning/choices.py
@@ -33,6 +33,26 @@ class AssuranceLevels(models.TextChoices):
     high = "urn:etoegang:core:assurance-class:loa4", _("High (4)")
 
 
+# ref: https://www.logius.nl/domeinen/toegang/digid/documentatie/koppelvlakspecificatie-digid-saml-authenticatie#index-23
+class DigiDAssuranceLevels(models.TextChoices):
+    base = (
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+        _("DigiD Basis"),
+    )
+    middle = (
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract",
+        _("DigiD Midden"),
+    )
+    substantial = (
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:Smartcard",
+        _("DigiD Substantieel"),
+    )
+    high = (
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI",
+        _("DigiD Hoog"),
+    )
+
+
 class XMLContentTypes(models.TextChoices):
     soap_xml = OneLogin_Saml2_Constants.SOAP_XML, "application/soap+xml"
     text_xml = OneLogin_Saml2_Constants.TEXT_XML, "text/xml"

--- a/digid_eherkenning/saml2/base.py
+++ b/digid_eherkenning/saml2/base.py
@@ -177,6 +177,15 @@ class BaseSaml2Client:
                 OneLogin_Saml2_ValidationError.WRONG_INRESPONSETO,
             )
 
+        # I remember reading somewhere that the assurance level on the response
+        # SHOULD be checked. But they might not be present on the response.
+        # From the SAML spec (saml-core-2.0-os):
+        #
+        # If the <RequestedAuthnContext> element is present in the query, at least one
+        # <AuthnStatement> element in the set of returned assertions MUST contain an
+        # <AuthnContext> element that satisfies the element in the query (see Section 3.3.2.2.1). It is
+        # OPTIONAL for the complete set of all such matching assertions to be returned in the response.
+
     def create_config(self, config_dict):
         """
         Convert to the format expected by the OneLogin SAML2 library.

--- a/digid_eherkenning/saml2/digid.py
+++ b/digid_eherkenning/saml2/digid.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 
 from furl import furl
 
+from ..choices import DigiDAssuranceLevels
 from ..models import DigidConfiguration
 from .base import BaseSaml2Client
 
@@ -15,6 +16,15 @@ def generate_digid_metadata() -> bytes:
 class DigiDClient(BaseSaml2Client):
     cache_key_prefix = "digid"
     cache_timeout = 60 * 60  # 1 hour
+
+    def __init__(
+        self,
+        *args,
+        loa: DigiDAssuranceLevels = DigiDAssuranceLevels.middle,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.loa = loa
 
     @property
     def conf(self) -> dict:
@@ -50,9 +60,7 @@ class DigiDClient(BaseSaml2Client):
                 "metadataValidUntil": "",
                 "metadataCacheDuration": "",
                 "requestedAuthnContextComparison": "minimum",
-                "requestedAuthnContext": [
-                    "urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract",
-                ],
+                "requestedAuthnContext": [self.loa],
             }
         )
         return super().create_config(config_dict)

--- a/digid_eherkenning/saml2/eherkenning.py
+++ b/digid_eherkenning/saml2/eherkenning.py
@@ -424,7 +424,7 @@ class eHerkenningClient(BaseSaml2Client):
     def __init__(
         self,
         *args,
-        loa: AssuranceLevels | None = None,
+        loa: Optional[AssuranceLevels] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)

--- a/digid_eherkenning/saml2/eherkenning.py
+++ b/digid_eherkenning/saml2/eherkenning.py
@@ -13,6 +13,7 @@ from lxml.builder import ElementMaker
 from lxml.etree import Element
 from OpenSSL import crypto
 
+from ..choices import AssuranceLevels
 from ..models import EherkenningConfiguration
 from ..settings import EHERKENNING_DS_XSD
 from ..utils import validate_xml
@@ -420,6 +421,15 @@ class eHerkenningClient(BaseSaml2Client):
     cache_key_prefix = "eherkenning"
     cache_timeout = 60 * 60  # 1 hour
 
+    def __init__(
+        self,
+        *args,
+        loa: AssuranceLevels | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.loa = loa
+
     @property
     def conf(self) -> dict:
         if not hasattr(self, "_conf"):
@@ -471,7 +481,7 @@ class eHerkenningClient(BaseSaml2Client):
                 "metadataCacheDuration": "",
                 "requestedAuthnContextComparison": "minimum",
                 "requestedAuthnContext": [
-                    self.conf["loa"],
+                    self.loa or self.conf["loa"],
                 ],
             }
         )

--- a/digid_eherkenning/saml2/eherkenning.py
+++ b/digid_eherkenning/saml2/eherkenning.py
@@ -1,7 +1,7 @@
 import binascii
 from base64 import b64encode
 from io import BytesIO
-from typing import List, Optional
+from typing import List, Literal, Union
 from uuid import uuid4
 
 from django.urls import reverse
@@ -424,7 +424,7 @@ class eHerkenningClient(BaseSaml2Client):
     def __init__(
         self,
         *args,
-        loa: Optional[AssuranceLevels] = None,
+        loa: Union[AssuranceLevels, Literal[""]] = "",
         **kwargs,
     ):
         super().__init__(*args, **kwargs)

--- a/digid_eherkenning/views/digid.py
+++ b/digid_eherkenning/views/digid.py
@@ -37,7 +37,7 @@ class DigiDLoginView(TemplateView):
 
     def get_level_of_assurance(self):
         """
-        Override the default Lever of Assurnace (middle).
+        Override the default Level of Assurance (middle).
 
         When overriding this, remember the user has control over the request!
         """

--- a/digid_eherkenning/views/digid.py
+++ b/digid_eherkenning/views/digid.py
@@ -17,7 +17,7 @@ from django.views.generic.base import TemplateView, View
 from onelogin.saml2.soap_logout_request import Soap_Logout_Request
 from onelogin.saml2.utils import OneLogin_Saml2_Error, OneLogin_Saml2_ValidationError
 
-from ..choices import SectorType
+from ..choices import DigiDAssuranceLevels, SectorType
 from ..forms import SAML2Form
 from ..saml2.digid import DigiDClient
 from ..utils import logout_user
@@ -35,6 +35,9 @@ class DigiDLoginView(TemplateView):
 
     template_name = "digid_eherkenning/post_binding.html"
 
+    def get_level_of_assurance(self):
+        return DigiDAssuranceLevels.middle
+
     def get_relay_state(self):
         """
         TODO: It might be a good idea to sign the relay state.
@@ -51,7 +54,8 @@ class DigiDLoginView(TemplateView):
     #
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        client = DigiDClient()
+        client = DigiDClient(loa=self.get_level_of_assurance())
+
         location, parameters = client.create_authn_request(self.request)
 
         context_data.update(

--- a/digid_eherkenning/views/digid.py
+++ b/digid_eherkenning/views/digid.py
@@ -36,6 +36,11 @@ class DigiDLoginView(TemplateView):
     template_name = "digid_eherkenning/post_binding.html"
 
     def get_level_of_assurance(self):
+        """
+        Override the default Lever of Assurnace (middle).
+
+        When overriding this, remember the user has control over the request!
+        """
         return DigiDAssuranceLevels.middle
 
     def get_relay_state(self):

--- a/digid_eherkenning/views/eherkenning.py
+++ b/digid_eherkenning/views/eherkenning.py
@@ -22,7 +22,7 @@ from .base import get_redirect_url
 class eHerkenningLoginView(TemplateView):
     template_name = "digid_eherkenning/post_binding.html"
 
-    def get_level_of_assurance(self) -> AssuranceLevels | None:
+    def get_level_of_assurance(self) -> Optional[AssuranceLevels]:
         """
         Override the AssuranceLevel from the global `EherkenningConfiguration`.
 

--- a/digid_eherkenning/views/eherkenning.py
+++ b/digid_eherkenning/views/eherkenning.py
@@ -27,6 +27,7 @@ class eHerkenningLoginView(TemplateView):
         Override the AssuranceLevel from the global `EherkenningConfiguration`.
 
         To use the level from the global config, return `None`
+        NB When overriding this, remember the user has control over the request!
         """
         return None
 

--- a/digid_eherkenning/views/eherkenning.py
+++ b/digid_eherkenning/views/eherkenning.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional, Union
 
 from django.conf import settings
 from django.contrib import auth, messages
@@ -10,11 +10,6 @@ from django.views.generic.base import TemplateView, View
 from ..choices import AssuranceLevels
 from ..exceptions import SAML2Error, eHerkenningNoRSINError
 from ..forms import SAML2Form
-
-# These two unused imports may be imported from here by 3rd party client code
-# ignoring F401 for now
-from ..saml2.eherkenning import generate_dienst_catalogus_metadata  # noqa: F401
-from ..saml2.eherkenning import generate_eherkenning_metadata  # noqa: F401
 from ..saml2.eherkenning import eHerkenningClient
 from .base import get_redirect_url
 
@@ -22,14 +17,14 @@ from .base import get_redirect_url
 class eHerkenningLoginView(TemplateView):
     template_name = "digid_eherkenning/post_binding.html"
 
-    def get_level_of_assurance(self) -> Optional[AssuranceLevels]:
+    def get_level_of_assurance(self) -> Union[AssuranceLevels, Literal[""]]:
         """
         Override the AssuranceLevel from the global `EherkenningConfiguration`.
 
-        To use the level from the global config, return `None`
+        To use the level from the global config, return `""`
         NB When overriding this, remember the user has control over the request!
         """
-        return None
+        return ""
 
     def get_relay_state(self):
         """


### PR DESCRIPTION
This PR allows for the a login view to override the LoA from the default/global config based on information in the request.
