### PR TITLE
:recycle: Use cryptography primivites for x509 certificate processing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
+    cryptography >= 40.0.0
     django >= 3.2.0
     django-sessionprofile
     django-simple-certmanager


### PR DESCRIPTION
Instead of relying on the (implicitly installed) PyOpenSSL dependency.