### PR TITLE
:package: Drop support for old python/django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
-        django: ['3.2', '4.1', '4.2']
-        exclude:
-          - python: '3.11'
-            django: '3.2'
+        python: ['3.10', '3.11', '3.12']
+        django: ['4.2']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+0.14.0 (2024-??-??)
+===================
+
+* Dropped support for Django versions older than 4.2 (LTS).
+* Dropped support for Python versions older than 3.10.
+* ...
+
 0.13.1 (2024-04-08)
 ===================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.rst
 include *.md
 include LICENSE
+include digid_eherkenning/py.typed
 recursive-include digid_eherkenning *.html
 recursive-include digid_eherkenning *.txt
 recursive-include digid_eherkenning *.po

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,6 @@ django-digid-eherkenning
 :Version: 0.13.1
 :Source: https://github.com/maykinmedia/django-digid-eherkenning
 :Keywords: django, authentication, digid, eherkenning, eidas, dutch, nl, netherlands
-:PythonVersion: 3.9+
 
 |build-status| |code-quality| |black| |coverage| |docs|
 

--- a/digid_eherkenning/management/commands/update_stored_metadata.py
+++ b/digid_eherkenning/management/commands/update_stored_metadata.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             config = EherkenningConfiguration.get_solo()
 
         if config.metadata_file_source:
-            config.save()
+            config.save(force_metadata_update=True)
             self.stdout.write(self.style.SUCCESS("Update was successful"))
         else:
             self.stdout.write(

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -27,7 +27,7 @@ Configuring RequestedAttribute
 In the field ``RequestedAttribute`` one can specify all the attributes that may be requested by the service
 when a company/person logs in with eHerkenning or eIDAS.
 
-The values specified need to come from the "`Attribuutcatalogus <https://afsprakenstelsel.etoegang.nl/display/as/Attribuutcatalogus>`_"
+The values specified need to come from the "`Attribuutcatalogus <https://afsprakenstelsel.etoegang.nl/Startpagina/v1/attribuutcatalogus>`_"
 (there are multiple catalogues: 'generiek', 'natuurlijke personen' and 'non-natuurlijke personen').
 
 In the admin, these can be specified as a list of dictionaries. For example, for eIDAS one could use the following JSON

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,9 +8,7 @@ Installation
 Requirements
 ------------
 
-* Python 3.7 or newer
-* setuptools 30.3.0 or above
-* Django 3.2
+* See the badges for the supported Python and Django versions
 * XML system packages, e.g. for Debian/Ubuntu:
 
     - ``libxml2-dev``

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,25 +17,24 @@ keywords = django, authentication, digid, eherkenning, eidas, dutch, nl, netherl
 classifiers =
     Development Status :: 4 - Beta
     Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
+python_requires = >= 3.10
 install_requires =
     cryptography >= 40.0.0
-    django >= 3.2.0
+    django >= 4.2.0
     django-sessionprofile
     django-simple-certmanager
     django-solo

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ class BaseModelTests(TestCase):
             )
             config.save()
 
-        self.assertTrue(get_matadata.called_once())
+        get_matadata.assert_called_once()
         self.assertEqual(
             config.idp_metadata_file.read().decode("utf-8"), metadata_content
         )
@@ -54,7 +54,7 @@ class BaseModelTests(TestCase):
             )
             config.save()
 
-        self.assertTrue(get_matadata.called_once())
+        get_matadata.assert_called_once()
         self.assertEqual(
             config.idp_metadata_file.read().decode("utf-8"), metadata_content
         )
@@ -81,7 +81,7 @@ class BaseModelTests(TestCase):
         config.save()
 
         # Make sure we don't try to fetch and parse again the xml file, since there is no update
-        self.assertTrue(get_matadata.called_once())
+        get_matadata.assert_called_once()
 
     @patch(
         "onelogin.saml2.idp_metadata_parser.OneLogin_Saml2_IdPMetadataParser.get_metadata"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{39,310}-django{32,41,42}
-    py311-django{41,42}
+    py{310,311,312}-django{42}
     isort
     black
     docs
@@ -9,14 +8,12 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
-    4.1: django41
     4.2: django42
 
 [testenv]
@@ -26,8 +23,6 @@ extras =
     tests
     coverage
 deps =
-  django32: Django~=3.2
-  django41: Django~=4.1
   django42: Django~=4.2
 install_command =
   python -I -m pip install {opts} --no-binary lxml {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,6 @@ extras =
     coverage
 deps =
   django42: Django~=4.2
-install_command =
-  python -I -m pip install {opts} --no-binary lxml {packages}
 commands =
   py.test tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \


### PR DESCRIPTION
* Dropped Django 3.2 and 4.1 support, these are no longer maintained
* Require Python 3.10+ so that we can use modern typing annotations syntax.