### PR TITLE
Offer metadata as file for download

### DIFF
--- a/digid_eherkenning/metadata_urls.py
+++ b/digid_eherkenning/metadata_urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
         MetadataView.as_view(
             config_model=DigidConfiguration,
             metadata_generator=generate_digid_metadata,
+            filename="digid-metadata.xml",
         ),
         name="digid",
     ),
@@ -24,6 +25,7 @@ urlpatterns = [
         MetadataView.as_view(
             config_model=EherkenningConfiguration,
             metadata_generator=generate_eherkenning_metadata,
+            filename="eh-metadata.xml",
         ),
         name="eherkenning",
     ),
@@ -32,6 +34,7 @@ urlpatterns = [
         MetadataView.as_view(
             config_model=EherkenningConfiguration,
             metadata_generator=generate_dienst_catalogus_metadata,
+            filename="dienstcatalogus.xml",
         ),
         name="eh-dienstcatalogus",
     ),

--- a/digid_eherkenning/saml2/digid.py
+++ b/digid_eherkenning/saml2/digid.py
@@ -12,7 +12,7 @@ def generate_digid_metadata() -> bytes:
     client.saml2_setting_kwargs = {"sp_validation_only": True}
     metadata = client.create_metadata()
     return (
-        b"<?xml version='1.0' encoding='UTF-8'?>" + metadata
+        b'<?xml version="1.0" encoding="UTF-8"?>\n' + metadata
         if not metadata.startswith(b"<?xml")
         else metadata
     )

--- a/digid_eherkenning/saml2/eherkenning.py
+++ b/digid_eherkenning/saml2/eherkenning.py
@@ -62,7 +62,7 @@ def generate_eherkenning_metadata():
     client.saml2_setting_kwargs = {"sp_validation_only": True}
     metadata = client.create_metadata()
     return (
-        b'<?xml version="1.0" encoding="UTF-8"?>' + metadata
+        b'<?xml version="1.0" encoding="UTF-8"?>\n' + metadata
         if not metadata.startswith(b"<?xml")
         else metadata
     )


### PR DESCRIPTION
Closes #75 

Using Content-Disposition attachment offers the file for download to the client rather than viewing it inline.

The actual reason the dislaying was botched was because of the content security policy which blocked styles (not sure how that works). However, if that were to be addressed, it leaves the certificate data newlines being displayed as spaces, still producing content that is not ready to copy-and-paste, so downloading a file is the best option.