### PR TITLE
:sparkles: Optionally validate DigiD mock IDP callback urls

### DIFF
--- a/digid_eherkenning/mock/conf.py
+++ b/digid_eherkenning/mock/conf.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.encoding import force_str
@@ -45,3 +46,16 @@ def get_idp_login_url():
         "digid-mock:login"
     )
     return resolve_url(url)
+
+
+def should_validate_idp_callback_urls() -> bool:
+    """
+    Whether to validate that the `next_url` and `cancel_urls` are safe
+    """
+    flag = getattr(settings, "DIGID_MOCK_IDP_VALIDATE_CALLBACK_URLS", settings.DEBUG)
+    if not isinstance(flag, bool):
+        raise ImproperlyConfigured(
+            "DIGID_MOCK_IDP_VALIDATE_CALLBACK_URLS should be a boolean"
+        )
+
+    return flag

--- a/digid_eherkenning/mock/idp/views/digid.py
+++ b/digid_eherkenning/mock/idp/views/digid.py
@@ -1,7 +1,7 @@
 import logging
 from urllib.parse import urlencode
 
-from django.http import HttpResponseBadRequest
+from django.http import HttpRequest, HttpResponseBadRequest
 from django.urls import reverse
 from django.views.generic import FormView, TemplateView
 
@@ -9,12 +9,30 @@ from furl import furl
 
 from digid_eherkenning.mock import conf
 from digid_eherkenning.mock.idp.forms import PasswordLoginForm
+from digid_eherkenning.views.base import get_redirect_url
 
 logger = logging.getLogger(__name__)
 
 
 class _BaseIDPViewMixin(TemplateView):
     page_title = "DigiD: Inloggen"
+
+    @staticmethod
+    def _is_allowed_callback(request: HttpRequest, url: str):
+        """
+        Determine whether `url` is an allowed callback for the mock IDP.
+
+        The callback URL should be a relative path, or match the host of the mock IDP
+        view. If the IDP is served under HTTPS, then the callback URL must also use
+        HTTPS.
+        """
+        return get_redirect_url(
+            request,
+            url,
+            # Unsafe redirects are not uncommon in development settings, but if the IDP
+            # is hosted behind TLS, the callbacks should also be secure.
+            require_https=request.is_secure(),
+        )
 
     def dispatch(self, request, *args, **kwargs):
         # we pass these variables through the URL instead of dealing with POST and sessions
@@ -33,6 +51,21 @@ class _BaseIDPViewMixin(TemplateView):
         if not self.cancel_url:
             logger.debug("missing 'cancel' parameter")
             return HttpResponseBadRequest("missing 'cancel' parameter")
+
+        # The principal use-case is that the mock IDP redirect flow all takes place
+        # within the same service. This should generally only be used in development,
+        # but out of an abundance of caution, and also to please security scanners, we
+        # only allow redirects to the same host that is serving the mock IDP should the
+        # IDP be active in world-facing environments (e.g. in acceptance). This behavior
+        # can be disabled with the DIGID_MOCK_IDP_VALIDATE_CALLBACK_URLS setting.
+        if conf.should_validate_idp_callback_urls():
+            if not self._is_allowed_callback(request, self.next_url):
+                return HttpResponseBadRequest("'next_url' parameter must be a safe url")
+
+            if not self._is_allowed_callback(request, self.cancel_url):
+                return HttpResponseBadRequest(
+                    "'cancel_url' parameter must be a safe url"
+                )
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Closes #85 