### PR TITLE
👷 Fix running tox locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -- ${{ matrix.oidc_enabled != 'yes' && '--ignore tests/oidc' || '' }}
+          tox
         env:
           PYTHON_VERSION: ${{ matrix.python }}
           DJANGO: ${{ matrix.django }}

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -104,8 +104,8 @@ DATABASES = {
             "NAME": os.getenv("PGDATABASE", "django_digid_eherkenning"),
             "USER": os.getenv("PGUSER", "django_digid_eherkenning"),
             "PASSWORD": os.getenv("PGPASSWORD", "django_digid_eherkenning"),
-            "HOST": os.getenv("DB_HOST", "localhost"),
-            "PORT": os.getenv("DB_PORT", 5432),
+            "HOST": os.getenv("PGHOST", "localhost"),
+            "PORT": os.getenv("PGPORT", 5432),
         }
         if OIDC_ENABLED
         else {

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ OIDC_ENABLED =
 setenv =
     PYTHONPATH={toxinidir}
     oidcenabled: OIDC_ENABLED=yes
+    oidcdisabled: IGNORE_OIDC=--ignore tests/oidc
 passenv =
     OIDC_ENABLED
     PGUSER
@@ -40,12 +41,13 @@ deps =
 commands =
   pytest tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \
+   {env:IGNORE_OIDC} \
    {posargs}
 
 [testenv:isort]
 extras = tests
 skipsdist = True
-commands = isort --check-only --diff .
+commands = isort --check-only --diff digid_eherkenning tests
 
 [testenv:black]
 extras = tests


### PR DESCRIPTION
I bumped into this when backporting a fix.

 - tox was passing PG{HOST,PORT}, but DB_{HOST,PORT} were actually used
 - oidcdisabled envs were failing locally, because only the GitHub workflow was ignoring the oidc suite correctly
 - isort was depending on skip and failing on my .venv; now it explicitly sorts, just like the :black env.