### PR TITLE
Include "next" certificate in service catalogue metadata

### DIFF
--- a/digid_eherkenning/saml2/eherkenning.py
+++ b/digid_eherkenning/saml2/eherkenning.py
@@ -329,7 +329,8 @@ def create_service_catalogus(conf: EHerkenningConfig, validate: bool = True) -> 
     """
     https://afsprakenstelsel.etoegang.nl/display/as/Service+catalog
     """
-    with conf["cert_file"].open("rb") as cert_file:
+    cert_file = conf["next_cert_file"] or conf["cert_file"]
+    with cert_file.open("rb") as cert_file:
         x509_certificate_content: bytes = cert_file.read()
 
     sc_id = str(uuid4())

--- a/digid_eherkenning/types.py
+++ b/digid_eherkenning/types.py
@@ -38,6 +38,7 @@ class EHerkenningConfig(TypedDict):
     entity_id: str
     metadata_file: str
     cert_file: Path | FieldFile
+    next_cert_file: Path | FieldFile | None
     key_file: Path | FieldFile
     service_entity_id: str
     oin: str


### PR DESCRIPTION
Fixes open-formulieren/open-forms#5136, pending a new release of this library of course.

The key descriptors in the service catalogue generation included the "old"/current certificates rather than the certificates that will (soon) replace them. Now the service catalogue generation uses the next certificate if it's available, falling back to the current certificate if it's not.