### PR TITLE
Temporarily pinned lxml to v5.3.1 to prevent mismatch with xmlsec issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ extras =
 deps =
   django42: Django~=4.2
   oidcenabled: psycopg
+  lxml==5.3.1
 commands =
   pytest tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \


### PR DESCRIPTION
Temporarily fixes a version mismatch between lxml and xmlsec:

![image](https://github.com/user-attachments/assets/53eb7937-40c1-4b0a-a524-8ba548ea8ed2)
