### PR TITLE
:pushpin: explicitly pin Django to <6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "cryptography>=40.0.0",
-    "django>=4.2.0",
+    "django>=4.2.0,<6.0.0",
     "django-sessionprofile",
     "django-simple-certmanager>=2.3.0",
     "django-solo",


### PR DESCRIPTION
Among other backwards incompatible changes, Django 6.0 deprecated the check= kwarg for database CheckConstraint, which breaks both our code base and migrations in several of our dependencies.

This commit makes explicit that we do not support Django >=6.0, until such time as we can properly look into this.

Closes: #106