### PR TITLE
Support django-privates 4 and django-simple-certmanager 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         django: ['4.2', '5.2']
         oidc_enabled: ['no', 'yes']
         exclude:
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version-file: 'pyproject.toml'
 
       - name: Build sdist and wheel
         run: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version-file: 'pyproject.toml'
 
       - name: Install OS dependencies
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,13 +8,13 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
-    python: "3.10"
+    python: "3.12"
   apt_packages:
     - libxml2-dev
     - libxmlsec1-dev
-    - libxmlsec1-openssl
+    - libxmlsec1-openssl1
 
 python:
   install:

--- a/digid_eherkenning/admin.py
+++ b/digid_eherkenning/admin.py
@@ -178,9 +178,9 @@ class ConfigCertificateAdmin(admin.ModelAdmin):
     list_display = (
         "config_type",
         "certificate",
-        "valid_from",
+        "not_valid_before",
         "activate_on",
-        "expiry_date",
+        "not_valid_after",
         "is_ready",
     )
     list_filter = ("config_type",)
@@ -188,12 +188,12 @@ class ConfigCertificateAdmin(admin.ModelAdmin):
     raw_id_fields = ("certificate",)
 
     @admin.display(description=_("valid from"))
-    def valid_from(self, obj: ConfigCertificate) -> datetime:
-        return obj.certificate.valid_from
+    def not_valid_before(self, obj: ConfigCertificate) -> datetime:
+        return obj.certificate.not_valid_before
 
     @admin.display(description=_("expires on"))
-    def expiry_date(self, obj: ConfigCertificate) -> datetime:
-        return obj.certificate.expiry_date
+    def not_valid_after(self, obj: ConfigCertificate) -> datetime:
+        return obj.certificate.not_valid_after
 
     @admin.display(description=_("valid candidate?"), boolean=True)
     def is_ready(self, obj: ConfigCertificate) -> bool:

--- a/digid_eherkenning/models/certificates.py
+++ b/digid_eherkenning/models/certificates.py
@@ -46,12 +46,12 @@ class ConfigCertificateQuerySet(models.QuerySet["ConfigCertificate"]):
 
         We look for the current certificate and the next with the following algorithm:
 
-        * order candidates by valid_from, so we favour existing/the oldest keypairs
-        * order candidates by expiry date, so if they have an identical valid_from, we
+        * order candidates by not_valid_before, so we favour existing/the oldest keypairs
+        * order candidates by expiry date, so if they have an identical not_valid_before, we
           favour the one that will expiry first (the other one(s) automatically become
           the next certificate
         * discard any candidates that do not meet our key pair requirements, ignoring
-          valid_from/until
+          not_valid_before/until
 
         To determine the current certificate:
 
@@ -63,11 +63,11 @@ class ConfigCertificateQuerySet(models.QuerySet["ConfigCertificate"]):
 
         If a candidate is found, we select the next certificate according to:
 
-        * must be valid_from >= current_certificate.valid_from
+        * must be not_valid_before >= current_certificate.not_valid_before
         * must not be expired
         """
         # XXX: check if this has a big performance impact because we extract the
-        # valid_from/until by loading the certificate files!
+        # not_valid_before/until by loading the certificate files!
         qs = self.filter(certificate__type=CertificateTypes.key_pair).iterator()
         # first pass - filter out anything that is not usable for SAML flows (
         # discarding broken/invalid configurations)
@@ -102,14 +102,15 @@ class ConfigCertificateQuerySet(models.QuerySet["ConfigCertificate"]):
                     assert_never(activate_on)
 
             return (
-                # certificate valid_from is always the lower bound for the activation timestamp
-                candidate.certificate.valid_from,
+                # certificate not_valid_before is always the lower bound for the
+                # activation timestamp
+                candidate.certificate.not_valid_before,
                 (activation_sort_key, activate_on or max_datetime),
                 # certificate expiry_date is always the upper bound for the activation timestamp
-                candidate.certificate.expiry_date,
+                candidate.certificate.not_valid_after,
             )
 
-        # sort them - we now know that we can safely access the valid_from and
+        # sort them - we now know that we can safely access the not_valid_before and
         # expiry_date attributes
         candidates = sorted(candidates, key=_candidate_sort_key)
 
@@ -125,7 +126,9 @@ class ConfigCertificateQuerySet(models.QuerySet["ConfigCertificate"]):
                 case (None, None) if candidate.is_ready_for_authn_requests:
                     current_cert = certificate
                     continue  # the same candidate cannot both be current and next
-                case (Certificate(), None) if certificate.expiry_date > timezone.now():
+                case (Certificate(), None) if (
+                    certificate.not_valid_after > timezone.now()
+                ):
                     next_cert = certificate
                     break  # we found both current and next
         else:
@@ -203,16 +206,16 @@ class ConfigCertificate(models.Model):
         super().clean()
 
         if self.activate_on and not (
-            (valid_from := self.certificate.valid_from)
+            (not_valid_before := self.certificate.not_valid_before)
             < self.activate_on
-            <= (expiry_date := self.certificate.expiry_date)
+            <= (not_valid_after := self.certificate.not_valid_after)
         ):
             error_message = _(
                 "The activation date cannot be before the certificate becomes valid "
                 "({valid_from}) or after its expiry ({expiry_date})."
             ).format(
-                valid_from=localize(timezone.localtime(valid_from)),
-                expiry_date=localize(timezone.localtime(expiry_date)),
+                valid_from=localize(timezone.localtime(not_valid_before)),
+                expiry_date=localize(timezone.localtime(not_valid_after)),
             )
             raise ValidationError({"activate_on": error_message})
 
@@ -256,10 +259,13 @@ class ConfigCertificate(models.Model):
             return False
 
         _certificate: Certificate = self.certificate
-        valid_from, expiry_date = _certificate.valid_from, _certificate.expiry_date
+        not_valid_before, not_valid_after = (
+            _certificate.not_valid_before,
+            _certificate.not_valid_after,
+        )
 
         now = timezone.now()
-        if not (valid_from <= now <= expiry_date):
+        if not (not_valid_before <= now <= not_valid_after):
             return False
 
         if self.activate_on and (now < self.activate_on):

--- a/digid_eherkenning/saml2/base.py
+++ b/digid_eherkenning/saml2/base.py
@@ -1,8 +1,11 @@
 import logging
+import tempfile
 from collections.abc import Callable
 
 from django.conf import settings
 from django.core.cache import cache
+from django.core.files.storage import FileSystemStorage, InMemoryStorage
+from django.db.models.fields.files import FieldFile
 from django.utils import timezone
 
 from furl import furl
@@ -77,6 +80,24 @@ def get_requested_attributes(conf: dict) -> list[dict]:
             )
 
     return requested_attributes
+
+
+def _ensure_file_exists_on_disk(field: FieldFile) -> str:
+    match field.storage:
+        case FileSystemStorage():
+            return field.path
+        case InMemoryStorage():
+            # TODO: figure out a solution to get these files/directories cleaned up once
+            # tests complete. Maybe setting up a signal dispatch?
+            tmp_input_file = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+            field.open("rb")
+            field.seek(0)
+            for chunk in field.chunks():
+                tmp_input_file.write(chunk)
+            tmp_input_file.flush()
+            return tmp_input_file.name
+        case _:  # pragma: no cover
+            raise NotImplementedError()
 
 
 class BaseSaml2Client:
@@ -239,6 +260,11 @@ class BaseSaml2Client:
             certificate = cert_file.read()
             privkey = key_file.read()
 
+        # testing support - ensure the certificate files exist *on-disk*, as these are
+        # passed as file-system paths to the underlying SSL libraries
+        key_file_path = _ensure_file_exists_on_disk(conf["key_file"])
+        cert_file_path = _ensure_file_exists_on_disk(conf["cert_file"])
+
         assert not conf["base_url"].endswith("/"), (
             "Base URL must not end with a trailing slash"
         )
@@ -252,8 +278,8 @@ class BaseSaml2Client:
                 "logoutResponseSigned": True,
                 "wantAssertionsEncrypted": conf.get("want_assertions_encrypted", False),
                 "wantAssertionsSigned": conf.get("want_assertions_signed", False),
-                "soapClientKey": conf["key_file"].path,
-                "soapClientCert": conf["cert_file"].path,
+                "soapClientKey": key_file_path,
+                "soapClientCert": cert_file_path,
                 # algorithm for requests with HTTP-redirect binding.
                 # AuthnRequest with HTTP-POST uses RSA_SHA256, which is hardcoded in OneLogin_Saml2_Auth.login_post
                 "signatureAlgorithm": conf.get(

--- a/digid_eherkenning/saml2/base.py
+++ b/digid_eherkenning/saml2/base.py
@@ -86,7 +86,7 @@ def _ensure_file_exists_on_disk(field: FieldFile) -> str:
     match field.storage:
         case FileSystemStorage():
             return field.path
-        case InMemoryStorage():
+        case InMemoryStorage():  # pragma: no cover - only relevant in tests
             # TODO: figure out a solution to get these files/directories cleaned up once
             # tests complete. Maybe setting up a signal dispatch?
             tmp_input_file = tempfile.NamedTemporaryFile(mode="wb", delete=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "cryptography>=40.0.0",
     "django>=4.2.0,<6.0.0",
     "django-sessionprofile",
-    "django-simple-certmanager>=2.3.0",
+    "django-simple-certmanager>=3.0.0",
     "django-solo",
     "lxml>=4.7.1",
     "furl",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 from io import BytesIO
 from pathlib import Path
 
@@ -66,10 +67,29 @@ EHERKENNING_TEST_CONFIG = {
 
 @pytest.fixture
 def temp_private_root(tmp_path, settings):
+    """
+    Set up a custom private root location that gets cleared up after tests.
+
+    Instead of using the in-memory approach of the unittest
+    privates.test.temp_private_root helper, we can rely on pytest cleaning up the
+    temporary directories here, so we use a real filesystem storage.
+    """
     tmpdir = tmp_path / "private-media"
     tmpdir.mkdir()
     location = str(tmpdir)
-    settings.PRIVATE_MEDIA_ROOT = location
+
+    _original = copy.deepcopy(settings.STORAGES)
+    new_storages = {
+        **_original,
+        "privates": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "OPTIONS": {
+                **_original["privates"].get("OPTIONS", {}),
+                "location": location,
+            },
+        },
+    }
+    settings.STORAGES = new_storages
     settings.SENDFILE_ROOT = location
     return settings
 

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -155,15 +155,29 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+    "privates": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "location": os.path.join(BASE_DIR, "private_media"),
+            "base_url": "/protected/",
+        },
+    },
+}
+
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
-PRIVATE_MEDIA_ROOT = os.path.join(BASE_DIR, "private_media")
-PRIVATE_MEDIA_URL = "/protected/"
-SENDFILE_ROOT = PRIVATE_MEDIA_ROOT
+SENDFILE_ROOT = os.path.join(BASE_DIR, "private_media")
 SENDFILE_BACKEND = "django_sendfile.backends.development"
 
 AUTHENTICATION_BACKENDS = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-django{42,52}-oidc{enabled,disabled}
-    py{313}-django{52}-oidc{enabled,disabled}
+    py{312,313}-django{42,52}-oidc{enabled,disabled}
     isort
     black
     docs
@@ -9,8 +8,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
     3.12: py312
     3.13: py313
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ passenv =
     PGHOST
 extras =
     tests
-    coverage
     oidcenabled: oidc
 deps =
   django42: Django~=4.2


### PR DESCRIPTION
In plan django tests (projects, not libraries), the `temp_private_root` helper sets up an in-memory storage, which breaks the SSL context machinery that expects a path to exist on disk. 30d5aa3e607d449c2b999927bb95309e93eec5c9 ensures that in those situations, the file is created on disk in a temp directory. I haven't found a quick and elegant mechanism yet to clean those up, so it kind-of keeps the status quo (those files weren't cleaned up before either with the temp private root, see sergei-maertens/django-privates#8).

Additionally while nuking my virtualenv I pulled in the latest django-simple-certmanager which has some breaking changes as well, so I handled them and now require at least that version to keep the code simple enough. The next release of django-digid-eherkenning will therefore also be technically breaking. We need to take a look at the python/django versions anyway, since privates 4 requires py312+ now anyway.